### PR TITLE
Remove resources from package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 test/
+resources/
 .eslintrc
 .travis.yml
 karma.conf.js


### PR DESCRIPTION
Let's make the package half as big as now. We don't need `example.png` in the `node_modules`.