### PR TITLE
Missing intersection when line merely touches arch

### DIFF
--- a/test/intersect.spec.js
+++ b/test/intersect.spec.js
@@ -255,6 +255,15 @@ describe('path-intersection', function() {
       ]
     });
 
+
+    test('line touching arch', {
+      p0: 'M20,1a10,10,0,0,1,-10,-10z',
+      p1: 'M0,0l16,0',
+      expectedIntersections: [
+        { x: 16, y: 0, segment1: 1, segment2: 1 }
+      ]
+    });
+
   });
 
 


### PR DESCRIPTION
This adds a failing test case for a situation exemplified on the images below:

<img width="679" alt="Screenshot 2019-12-16 at 11 03 02" src="https://user-images.githubusercontent.com/28307541/70897830-bc024200-1ff3-11ea-9616-c21af30e59e4.png">

The test case is derived from the diagram below:

<img width="1003" alt="Screenshot 2019-12-16 at 10 39 38" src="https://user-images.githubusercontent.com/28307541/70897829-bc024200-1ff3-11ea-89b4-97356bc8f5f9.png">
