### PR TITLE
Fix bug in regex for scientific notation

### DIFF
--- a/intersect.js
+++ b/intersect.js
@@ -17,7 +17,7 @@ var p2s = /,?([a-z]),?/gi,
     pow = math.pow,
     abs = math.abs,
     pathCommand = /([a-z])[\s,]*((-?\d*\.?\d*(?:e[-+]?\d+)?[\s]*,?[\s]*)+)/ig,
-    pathValues = /(-?\d*\.?\d*(?:e[-+]?\\d+)?)[\s]*,?[\s]*/ig;
+    pathValues = /(-?\d*\.?\d*(?:e[-+]?\d+)?)[\s]*,?[\s]*/ig;
 
 var isArray = Array.isArray || function(o) { return o instanceof Array; };
 

--- a/test/intersect.spec.js
+++ b/test/intersect.spec.js
@@ -236,6 +236,15 @@ describe('path-intersection', function() {
       ]
     });
 
+
+    test('points with scientific notation', {
+      p0: 'M1.12345e-15,1.12345e-15 L100,100',
+      p1: 'M100,0 L0,100',
+      expectedIntersections: [
+        { x: 50, y: 50, segment1: 1, segment2: 1 }
+      ]
+    });
+
   });
 
 


### PR DESCRIPTION
The stray backslash prevented parsing of path strings that include
values with scientific notation, quietly claiming there was no
intersection.

Closes #18
Closes #17