### PR TITLE
fix: types declaration file matches implementation

### DIFF
--- a/intersect.d.ts
+++ b/intersect.d.ts
@@ -34,7 +34,7 @@ declare function findPathIntersections(path1: Path, path2: Path, justCount: fals
 declare function findPathIntersections(path1: Path, path2: Path): Intersection[];
 declare function findPathIntersections(path1: Path, path2: Path, justCount?: boolean): Intersection[] | number;
 
-export = findPathIntersections;
+export default findPathIntersections;
 
 /**
  * A string in the form of 'M150,150m0,-18a18,18,0,1,1,0,36a18,18,0,1,1,0,-36z'
@@ -91,3 +91,5 @@ declare interface Intersection {
    */
   t2: number;
 }
+
+export type { Intersection, Path, PathComponent };


### PR DESCRIPTION
I saw the package has recently been switched to ESModule which is great.

The new _implementation_ is `export default function findPathIntersections(...)`, but the `.d.ts` _declaration_ is still as `export = findPathIntersections` which causes issues with TypeScript, as importing the default export is not recognised despite being correct. This PR amends this.

Still in the topic of TypeScript issues, keeping the lib's interfaces private causes `ts(4023) Exported variable 'X' has or is using name 'Intersection' from external module "Y" but cannot be named.`. I had to lookup this one but the fix here is just to export the interface, allowing other modules to reference, or _name_, the used types. 

Thanks for that useful lib!