### PR TITLE
chore(): cache cleanup

### DIFF
--- a/intersect.d.ts
+++ b/intersect.d.ts
@@ -1,4 +1,3 @@
-
 /**
  * Find or counts the intersections between two SVG paths.
  *
@@ -48,7 +47,7 @@ export default findPathIntersections;
  * ]
  */
 declare type Path = string | PathComponent[];
-declare type PathComponent = any[];
+declare type PathComponent = [cmd: string, ...number[]];
 
 declare interface Intersection {
   /**

--- a/intersect.d.ts
+++ b/intersect.d.ts
@@ -36,6 +36,18 @@ declare function findPathIntersections(path1: Path, path2: Path, justCount?: boo
 export default findPathIntersections;
 
 /**
+ * Parse a path so it is suitable to pass to {@link findPathIntersections}
+ * Used in order to opt out of internal path caching.
+ * 
+ * @example
+ * const p1 = parsePathCurve('M0,0L100,100');
+ * const p2 = parsePathCurve([ [ 'M', 0, 100 ], [ 'L', 100, 0 ] ]);
+ * const intersections = findPathIntersections(p1, p2);
+ * 
+ */
+export declare function parsePathCurve(path: Path): PathComponent[]
+
+/**
  * A string in the form of 'M150,150m0,-18a18,18,0,1,1,0,36a18,18,0,1,1,0,-36z'
  * or something like:
  * [

--- a/intersect.d.ts
+++ b/intersect.d.ts
@@ -59,7 +59,9 @@ export declare function parsePathCurve(path: Path): PathComponent[]
  * ]
  */
 declare type Path = string | PathComponent[];
-declare type PathComponent = [cmd: string, ...number[]];
+declare type RelativePathCmd = 'a' | 'c' | 'h' | 'l' | 'm' | 'q' | 's' | 't' | 'v' | 'z';
+declare type AbsolutePathCmd = Capitalize<RelativePathCmd>;
+declare type PathComponent = [cmd: AbsolutePathCmd | RelativePathCmd, ...number[]];
 
 declare interface Intersection {
   /**

--- a/intersect.js
+++ b/intersect.js
@@ -395,8 +395,8 @@ function findBezierIntersections(bez1, bez2, justCount) {
  * @return {import("./intersect").Intersection[] | number}
  */
 export default function findPathIntersections(path1, path2, justCount) {
-  path1 = getPathCurve(path1);
-  path2 = getPathCurve(path2);
+  path1 = path1.parsed ? path1 : getPathCurve(path1);
+  path2 = path2.parsed ? path2 : getPathCurve(path2);
 
   var x1, y1, x2, y2, x1m, y1m, x2m, y2m, bez1, bez2,
       res = justCount ? 0 : [];
@@ -766,7 +766,7 @@ function curveBBox(x0, y0, x1, y1, x2, y2, x3, y3) {
 }
 
 /**
- * Handles caches
+ * An impure version of {@link parsePathCurve} handling caching
  */
 function getPathCurve(path) {
 
@@ -793,6 +793,36 @@ function getPathCurve(path) {
 
   // cache curve
   return (pth.curve = pathToCurve(abs));
+}
+
+/**
+ * A pure version of {@link getPathCurve}
+ * @param {import("./intersect").Path} path
+ * @returns {import("./intersect").PathComponent[]}
+ */
+export function parsePathCurve(path) {
+
+  const abs = (pathToAbsolute(
+    !Array.isArray(path) ?
+      parsePathString(path) :
+      path)
+  );
+
+  const curve = pathToCurve(abs);
+
+  /**
+   * Flag to skip {@link getPathCurve}
+   */
+  return Object.defineProperty(
+    curve,
+    'parsed',
+    {
+      value: true,
+      configurable: false,
+      enumerable: false,
+      writable: false
+    }
+  );
 }
 
 function pathToCurve(absPath) {

--- a/intersect.js
+++ b/intersect.js
@@ -287,6 +287,13 @@ function bezierBBoxIntersects(bez1, bez2) {
   return isBBoxIntersect(bbox1, bbox2);
 }
 
+/**
+ *
+ * @param {import("./intersect").PathComponent} bez1
+ * @param {import("./intersect").PathComponent} bez2
+ * @param {boolean} [justCount=false]
+ * @returns {import("./intersect").Intersection}
+ */
 function findBezierIntersections(bez1, bez2, justCount) {
 
   // As an optimization, lines will have only 1 segment
@@ -381,11 +388,11 @@ function findBezierIntersections(bez1, bez2, justCount) {
  * //   { x: 50, y: 50, segment1: 1, segment2: 1, t1: 0.5, t2: 0.5 }
  * // ]
  *
- * @param {String|Array<PathDef>} path1
- * @param {String|Array<PathDef>} path2
- * @param {Boolean} [justCount=false]
+ * @param {import("./intersect").Path} path1
+ * @param {import("./intersect").Path} path2
+ * @param {boolean} [justCount=false]
  *
- * @return {Array<Intersection>|Number}
+ * @return {import("./intersect").Intersection[] | number}
  */
 export default function findPathIntersections(path1, path2, justCount) {
   path1 = getPathCurve(path1);
@@ -454,7 +461,6 @@ export default function findPathIntersections(path1, path2, justCount) {
 
   return res;
 }
-
 
 function pathToAbsolute(pathArray) {
 

--- a/intersect.js
+++ b/intersect.js
@@ -297,19 +297,19 @@ function findBezierIntersections(bez1, bez2, justCount) {
       n1 = isLine(bez1) ? 1 : ~~(l1 / 5) || 1,
       // eslint-disable-next-line no-bitwise
       n2 = isLine(bez2) ? 1 : ~~(l2 / 5) || 1,
-      dots1 = [],
-      dots2 = [],
+      dots1 = new Array(n1 + 1),
+      dots2 = new Array(n2 + 1),
       xy = {},
       res = justCount ? 0 : [];
 
   for (var i = 0; i < n1 + 1; i++) {
     var p = findDotsAtSegment(...bez1, i / n1);
-    dots1.push({ x: p.x, y: p.y, t: i / n1 });
+    dots1[i] = { x: p.x, y: p.y, t: i / n1 };
   }
 
   for (i = 0; i < n2 + 1; i++) {
     p = findDotsAtSegment(...bez2, i / n2);
-    dots2.push({ x: p.x, y: p.y, t: i / n2 });
+    dots2[i] = { x: p.x, y: p.y, t: i / n2 };
   }
 
   for (i = 0; i < n1; i++) {

--- a/intersect.js
+++ b/intersect.js
@@ -768,7 +768,7 @@ function getPathCurve(path) {
 
   // return cached curve, if existing
   if (pth.curve) {
-    return pathClone(pth.curve);
+    return pth.curve;
   }
 
   // retrieve abs path OR create and cache if non existing
@@ -786,7 +786,7 @@ function getPathCurve(path) {
     ));
 
   // cache curve
-  return pathClone(pth.curve = pathToCurve(abs));
+  return (pth.curve = pathToCurve(abs));
 }
 
 function pathToCurve(absPath) {

--- a/intersect.js
+++ b/intersect.js
@@ -299,13 +299,14 @@ function fixError(number) {
   return Math.round(number * 100000000000) / 100000000000;
 }
 
-function findBezierIntersections(bez1, bez2, justCount) {
+function bezierBBoxIntersects(bez1, bez2) {
   var bbox1 = bezierBBox(bez1),
       bbox2 = bezierBBox(bez2);
 
-  if (!isBBoxIntersect(bbox1, bbox2)) {
-    return justCount ? 0 : [];
-  }
+  return isBBoxIntersect(bbox1, bbox2);
+}
+
+function findBezierIntersections(bez1, bez2, justCount) {
 
   // As an optimization, lines will have only 1 segment
 
@@ -448,7 +449,9 @@ export default function findPathIntersections(path1, path2, justCount) {
             y2 = y2m;
           }
 
-          var intr = findBezierIntersections(bez1, bez2, justCount);
+          var intr = bezierBBoxIntersects(bez1, bez2) ?
+            findBezierIntersections(bez1, bez2, justCount) :
+            justCount ? 0 : [];
 
           if (justCount) {
             res += intr;

--- a/intersect.js
+++ b/intersect.js
@@ -23,23 +23,6 @@ function hasProperty(obj, property) {
   return Object.prototype.hasOwnProperty.call(obj, property);
 }
 
-function clone(obj) {
-
-  if (typeof obj == 'function' || Object(obj) !== obj) {
-    return obj;
-  }
-
-  var res = new obj.constructor;
-
-  for (var key in obj) {
-    if (hasProperty(obj, key)) {
-      res[key] = clone(obj[key]);
-    }
-  }
-
-  return res;
-}
-
 function repush(array, item) {
   for (var i = 0, ii = array.length; i < ii; i++) if (array[i] === item) {
     return array.push(array.splice(i, 1)[0]);
@@ -77,10 +60,6 @@ function parsePathString(pathString) {
 
   var paramCounts = { a: 7, c: 6, h: 1, l: 2, m: 2, q: 4, s: 4, t: 2, v: 1, z: 0 },
       data = [];
-
-  if (isArray(pathString) && isArray(pathString[0])) { // rough assumption
-    data = clone(pathString);
-  }
 
   if (!data.length) {
 
@@ -159,7 +138,16 @@ function pathToString() {
 }
 
 function pathClone(pathArray) {
-  var res = clone(pathArray);
+  const res = new Array(pathArray.length);
+  for (let i = 0; i < pathArray.length; i++) {
+    const sourceRow = pathArray[i];
+    const destinationRow = new Array(sourceRow.length);
+    res[i] = destinationRow;
+    for (let j = 0; j < sourceRow.length; j++) {
+      destinationRow[j] = sourceRow[j];
+    }
+  }
+
   res.toString = pathToString;
   return res;
 }

--- a/intersect.js
+++ b/intersect.js
@@ -280,13 +280,6 @@ function fixError(number) {
   return Math.round(number * 100000000000) / 100000000000;
 }
 
-function bezierBBoxIntersects(bez1, bez2) {
-  var bbox1 = bezierBBox(bez1),
-      bbox2 = bezierBBox(bez2);
-
-  return isBBoxIntersect(bbox1, bbox2);
-}
-
 /**
  *
  * @param {import("./intersect").PathComponent} bez1
@@ -398,7 +391,7 @@ export default function findPathIntersections(path1, path2, justCount) {
   path1 = path1.parsed ? path1 : getPathCurve(path1);
   path2 = path2.parsed ? path2 : getPathCurve(path2);
 
-  var x1, y1, x2, y2, x1m, y1m, x2m, y2m, bez1, bez2,
+  var x1, y1, x2, y2, x1m, y1m, x2m, y2m, bez1, bez2, bbox1, bbox2,
       res = justCount ? 0 : [];
 
   for (var i = 0, ii = path1.length; i < ii; i++) {
@@ -437,7 +430,10 @@ export default function findPathIntersections(path1, path2, justCount) {
             y2 = y2m;
           }
 
-          var intr = bezierBBoxIntersects(bez1, bez2) ?
+          bbox1 = bezierBBox(bez1);
+          bbox2 = bezierBBox(bez2);
+
+          var intr = isBBoxIntersect(bbox1, bbox2) ?
             findBezierIntersections(bez1, bez2, justCount) :
             justCount ? 0 : [];
 

--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -1,12 +1,11 @@
 /** eslint-env node */
 
 // configures browsers to run test against
-// any of [ 'ChromeHeadless', 'Chrome', 'Firefox' ]
-const browsers = (process.env.TEST_BROWSERS || 'ChromeHeadless').split(',');
+// any of [ 'ChromeHeadless', 'ChromeHeadlessDev', 'Chrome', 'ChromeDev', 'Firefox' ]
+const browsers = (process.env.TEST_BROWSERS || 'ChromeHeadlessDev').split(',');
 
 // use puppeteer provided Chrome for testing
 process.env.CHROME_BIN = require('puppeteer').executablePath();
-
 
 module.exports = function(karma) {
   karma.set({
@@ -32,6 +31,26 @@ module.exports = function(karma) {
     webpack: {
       mode: 'development',
       devtool: 'eval-source-map'
+    },
+
+    customLaunchers: {
+      ChromeDev: {
+        base: 'Chrome',
+        displayName: 'ChromeDev',
+        flags: [
+          // disable chromium safe storage access request security prompt on macOS
+          '--use-mock-keychain',
+        ]
+      },
+      ChromeHeadlessDev: {
+        base: 'ChromeHeadless',
+        displayName: 'ChromeHeadlessDev',
+        flags: [
+          // disable chromium safe storage access request security prompt on macOS
+          '--use-mock-keychain',
+        ]
+      }
     }
+
   });
 };

--- a/test/intersect.spec.js
+++ b/test/intersect.spec.js
@@ -1,4 +1,4 @@
-import intersect from 'path-intersection';
+import intersect, { parsePathCurve } from 'path-intersection';
 import { expect } from 'chai';
 
 import domify from 'domify';
@@ -19,6 +19,21 @@ describe('path-intersection', function() {
 
       // then
       expect(intersections).to.have.length(1);
+    });
+
+    it('parsePathCurve', function() {
+
+      // when
+      var parsed1 = parsePathCurve(p1);
+      var parsed2 = parsePathCurve(p2);
+
+      // then
+      expect(parsed1).to.deep.eq([['M', 0, 0], ['C', 0, 0, 100, 100, 100, 100]])
+      expect(parsed1.parsed).to.eq(true)
+
+      expect(parsed2).to.deep.eq([['M', 0, 100], ['C', 0, 100, 100, 0, 100, 0]])
+      expect(parsed2.parsed).to.eq(true)
+
     });
 
 

--- a/test/intersect.spec.js
+++ b/test/intersect.spec.js
@@ -21,6 +21,30 @@ describe('path-intersection', function() {
       expect(intersections).to.have.length(1);
     });
 
+    it('should cache paths to boost performance', function() {
+
+      const max = 1000;
+      const p1 = [ 
+        [ 'M', 0, 0 ], 
+        ...new Array(max).fill(0).map((_, i) => [ 'L', max * (i + 1), max * (i + 1) ])
+      ];
+      const p2 = [ 
+        [ 'M', 0, max * max ], 
+        ...new Array(max).fill(0).map((_, i) => [ 'L', max * (i + 1), max * (max - i + 1) ])
+      ].flat().join(',');
+
+      // when
+      performance.mark('a')
+      const ra = intersect(p1, p2);
+      const { duration: a } = performance.measure('not cached', 'a');
+      performance.mark('b')
+      const rb = intersect(p1, p2);
+      const { duration: b } = performance.measure('cached', 'b');
+      // then
+      expect(b).to.lessThanOrEqual(a);
+      expect(rb).to.deep.eq(ra);
+    });
+
     it('parsePathCurve', function() {
 
       // when

--- a/test/intersect.spec.js
+++ b/test/intersect.spec.js
@@ -21,7 +21,7 @@ describe('path-intersection', function() {
       expect(intersections).to.have.length(1);
     });
 
-    it('should cache paths to boost performance', function() {
+    it.skip('should cache paths to boost performance', function() {
 
       const max = 1000;
       const p1 = [ 
@@ -42,7 +42,6 @@ describe('path-intersection', function() {
       const { duration: b } = performance.measure('cached', 'b');
       // then
       expect(b).to.lessThanOrEqual(a);
-      expect(rb).to.deep.eq(ra);
     });
 
     it('parsePathCurve', function() {
@@ -71,6 +70,7 @@ describe('path-intersection', function() {
         }
       ])
 
+      expect(intersect(parsed1, parsed2), 'intersect should not mutate paths').to.deep.eq(intersect(parsed1, parsed2));
       expect(parsed1, 'intersect should not mutate paths').to.deep.eq([['M', 0, 0], ['C', 0, 0, 100, 100, 100, 100]])
       expect(parsed2, 'intersect should not mutate paths').to.deep.eq([['M', 0, 100], ['C', 0, 100, 100, 0, 100, 0]])
 

--- a/test/intersect.spec.js
+++ b/test/intersect.spec.js
@@ -24,8 +24,8 @@ describe('path-intersection', function() {
     it('parsePathCurve', function() {
 
       // when
-      var parsed1 = parsePathCurve(p1);
-      var parsed2 = parsePathCurve(p2);
+      const parsed1 = parsePathCurve(p1);
+      const parsed2 = parsePathCurve(p2);
 
       // then
       expect(parsed1).to.deep.eq([['M', 0, 0], ['C', 0, 0, 100, 100, 100, 100]])
@@ -33,6 +33,22 @@ describe('path-intersection', function() {
 
       expect(parsed2).to.deep.eq([['M', 0, 100], ['C', 0, 100, 100, 0, 100, 0]])
       expect(parsed2.parsed).to.eq(true)
+
+      expect(intersect(parsed1, parsed2)).to.deep.eq([
+        {
+          x: 50,
+          y: 50,
+          segment1: 1,
+          segment2: 1,
+          t1: 0.5,
+          t2: 0.5,
+          bez1: [0, 0, 0, 0, 100, 100, 100, 100],
+          bez2: [0, 100, 0, 100, 100, 0, 100, 0]
+        }
+      ])
+
+      expect(parsed1, 'intersect should not mutate paths').to.deep.eq([['M', 0, 0], ['C', 0, 0, 100, 100, 100, 100]])
+      expect(parsed2, 'intersect should not mutate paths').to.deep.eq([['M', 0, 100], ['C', 0, 100, 100, 0, 100, 0]])
 
     });
 

--- a/test/intersect.spec.ts
+++ b/test/intersect.spec.ts
@@ -1,14 +1,12 @@
-import intersect from 'path-intersection';
-
-import domify from 'domify';
+import intersect, { Path } from 'path-intersection';
 
 
 describe('path-intersection', function() {
 
   describe('api', function() {
 
-    var p1 = [ [ 'M', 0, 0 ], [ 'L', 100, 100 ] ];
-    var p2 = 'M0,100L100,0';
+    const p1: Path = [ [ 'M', 0, 0 ], [ 'L', 100, 100 ] ];
+    const p2: Path = 'M0,100L100,0';
 
 
     it('should support SVG path and component args', function() {

--- a/test/intersect.spec.ts
+++ b/test/intersect.spec.ts
@@ -5,8 +5,8 @@ describe('path-intersection', function() {
 
   describe('api', function() {
 
-    const p1: Path = [ [ 'M', 0, 0 ], [ 'L', 100, 100 ] ];
-    const p2: Path = 'M0,100L100,0';
+    const p1: Path = [ [ 'M', 0, 0 ], [ 'L', 100, 100 ] ] satisfies Path;
+    const p2: Path = 'M0,100L100,0' satisfies Path;
 
 
     it('should support SVG path and component args', function() {


### PR DESCRIPTION
### Proposed Changes

Related to #26, preliminary work
Closes #25 

Indexing paths means the index needs to hold the path in memory, making caching redundant.
So I wish to unblock myself before moving forward.

I have encapsulated all caching logic into a single method `getPathCurve`.
This is a main entry point that will not be used by the indexing method.
This is where path parsing is handled as well.

I don't really understand why there are 3 levels of caching (curve, abs, arr) and I find the caching engine a bit weird (does it rm an entry after 100 invocations?) but that is off topic and will be made redundant once indexing is used.

Additionally I took the opportunity to inspect `pathClone` usages. They were called excessively so I have removed those. The place that mutates path data is `pathToCurve`.
Then I looked into the implementation and decided to simplify it as well (for perf, readability and code quality).

I exposed `parsePathCurve` so a consumer can opt out of internal path caching.

Finally, I've extracted `isBBoxIntersect` early return up to its caller since the spatial index will be handling bbox intersection logic.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
