### PR TITLE
chore: pre-allocate dots arrays

### DIFF
--- a/intersect.js
+++ b/intersect.js
@@ -328,24 +328,25 @@ function findBezierIntersections(bez1, bez2, justCount) {
       n1 = isLine(bez1) ? 1 : ~~(l1 / 5) || 1,
       // eslint-disable-next-line no-bitwise
       n2 = isLine(bez2) ? 1 : ~~(l2 / 5) || 1,
-      dots1 = [],
-      dots2 = [],
+      dots1 = new Array(n1 + 1),
+      dots2 = new Array(n2 + 1),
       xy = {},
-      res = justCount ? 0 : [];
+      res = justCount ? 0 : [],
+      i, j;
 
-  for (var i = 0; i < n1 + 1; i++) {
+  for (i = 0; i < n1 + 1; i++) {
     var p = findDotsAtSegment(...bez1, i / n1);
-    dots1.push({ x: p.x, y: p.y, t: i / n1 });
+    dots1[i] = { x: p.x, y: p.y, t: i / n1 };
   }
 
   for (i = 0; i < n2 + 1; i++) {
     p = findDotsAtSegment(...bez2, i / n2);
-    dots2.push({ x: p.x, y: p.y, t: i / n2 });
+    dots2[i] = { x: p.x, y: p.y, t: i / n2 };
   }
 
   for (i = 0; i < n1; i++) {
 
-    for (var j = 0; j < n2; j++) {
+    for (j = 0; j < n2; j++) {
       var di = dots1[i],
           di1 = dots1[i + 1],
           dj = dots2[j],


### PR DESCRIPTION
### Proposed Changes

In the spirit of https://github.com/bpmn-io/path-intersection/commit/9050cb5b36ca94727913536abacc126d80182905, pre-allocate an additional array. The array size is fixed, as evident in the source code.

Originally proposed via https://github.com/bpmn-io/path-intersection/pull/27.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
